### PR TITLE
Added support for vmnet values to vnet_cli.

### DIFF
--- a/vmfusion/__init__.py
+++ b/vmfusion/__init__.py
@@ -283,8 +283,47 @@ class dhcpd_leases( object ):
 class vnet_cli(object):
     def __init__( self, name ):
         self.name = name
-        self.leases = dhcpd_leases( '/var/db/vmware/vmnet-dhcpd-' + name + '.leases' )
-        self.leases.load()
+        self._parse_networking()
+        self._load_dhcp_leases()
+
+    def _load_dhcp_leases(self):
+        try:
+            path = '/var/db/vmware/vmnet-dhcpd-{}.leases'
+            self.leases = dhcpd_leases( path.format(self.name) )
+            self.leases.load()
+        except ValueError:
+            self.leases = None
+
+    def _parse_networking(self):
+        netfile = "/Library/Preferences/VMware Fusion/networking"
+        net_num = self.name[-1]
+        net_name = "VNET_{0}".format(net_num)
+        match = re.compile("answer\s+{0}_(\w+)\s+(.*)$".format(net_name)).match
+        attrs = {}
+
+        with open(netfile) as net:
+            content = net.read()
+            if net_name not in content:
+                msg = "No network named {0} is defined!"
+                raise ValueError(msg.format(self.name))
+
+            for line in content.split("\n"):
+                m = match(line)
+                if m:
+                    attr = m.group(1).lower()
+                    val = m.group(2)
+                    if val == 'yes':
+                        val = True
+                    elif val == 'no':
+                        val = False
+                    attrs[attr] = val
+
+        self.dhcp = attrs.get("dhcp", False)
+        self.netmask = attrs.get("hostonly_netmask", None)
+        self.subnet = attrs.get("hostonly_subnet", None)
+        self.nat = attrs.get("nat", False)
+        self.virtual_adapter = attrs.get("virtual_adapter", False)
+
 
 # Default access
 vmrun = vmrun_cli()


### PR DESCRIPTION
- Adds configuration values to the vnet_cli vmnet lookup.
- No longer assumes dhcp is enabled on a net, leases set to None if dhcp
  disabled.
- Converts 'yes' and 'no' to True and False respectively.

Example::

```
>>> net = vmfusion.vnet_cli("vnet6")
Traceback (most recent call last):
File "<ipython-input-41-26cf6871e9c5>", line 1, in <module>
    net = vmfusion.vnet_cli("vnet6")
File "vmfusion/__init__.py", line 292, in __init__
    self._parse_networking()
File "vmfusion/__init__.py", line 305, in _parse_networking
    raise ValueError(msg.format(self.name))
ValueError: No network named vnet6 is defined!

>>> net = vmfusion.vnet_cli("vmnet2")
>>> net.dhcp
False
>>> net.netmask
'255.255.255.0'
>>> net.subnet
'192.168.100.0'
>>> net.nat
True
>>> net.virtual_adapter
True
```
